### PR TITLE
Add new gacha rarities and null reward handling

### DIFF
--- a/src/components/GachaPanel.tsx
+++ b/src/components/GachaPanel.tsx
@@ -7,7 +7,7 @@ import { ItemCard } from './ItemCard';
 import { Coins, Gem, Sparkles } from 'lucide-react';
 
 export const GachaPanel: React.FC = () => {
-  const { gameState, spendResources, addToInventory, updateStats } = useGameState();
+  const { gameState, spendResources, addToInventory, updateStats, updateResources } = useGameState();
   const [selectedPool, setSelectedPool] = useState<GachaPool>(GACHA_POOLS[0]);
   const [summoning, setSummoning] = useState(false);
   const [lastSummonResults, setLastSummonResults] = useState<Item[]>([]);
@@ -23,12 +23,24 @@ export const GachaPanel: React.FC = () => {
     
     // Simulate summon animation delay
     setTimeout(() => {
-      const results = count === 1 
+      const results = count === 1
         ? [GachaService.performSummon(selectedPool)]
         : GachaService.performMultiSummon(selectedPool, count);
-      
-      results.forEach(item => addToInventory(item));
-      setLastSummonResults(results);
+
+      let basicRewards = 0;
+      results.forEach(item => {
+        if (item) {
+          addToInventory(item);
+        } else {
+          basicRewards += 10; // fallback reward
+        }
+      });
+
+      if (basicRewards > 0) {
+        updateResources({ coins: gameState.resources.coins + basicRewards });
+      }
+
+      setLastSummonResults(results.filter((i): i is Item => i !== null));
       
       updateStats({
         totalSummons: gameState.stats.totalSummons + count

--- a/src/data/gachaPools.ts
+++ b/src/data/gachaPools.ts
@@ -8,15 +8,17 @@ export const GACHA_POOLS: GachaPool[] = [
     cost: 100,
     currency: 'coins',
     rates: {
-      [Rarity.COMMON]: 0.6,      // 60%
-      [Rarity.UNCOMMON]: 0.25,   // 25%
-      [Rarity.RARE]: 0.1,        // 10%
-      [Rarity.EPIC]: 0.04,       // 4%
-      [Rarity.LEGENDARY]: 0.01,  // 1%
-      [Rarity.MYTHIC]: 0.0        // 0%
+      [Rarity.COMMON]: 0.55,      // 55%
+      [Rarity.UNCOMMON]: 0.25,    // 25%
+      [Rarity.RARE]: 0.1,         // 10%
+      [Rarity.SUPER_RARE]: 0.05,  // 5%
+      [Rarity.EPIC]: 0.03,        // 3%
+      [Rarity.LEGENDARY]: 0.01,   // 1%
+      [Rarity.MYTHIC]: 0.005,     // 0.5%
+      [Rarity.IMMORTAL]: 0.0      // 0%
     },
-    availableItems: ITEM_TEMPLATES.filter(item => 
-      item.rarity !== Rarity.MYTHIC
+    availableItems: ITEM_TEMPLATES.filter(item =>
+      item.rarity !== Rarity.MYTHIC && item.rarity !== Rarity.IMMORTAL
     )
   },
   {
@@ -25,12 +27,14 @@ export const GACHA_POOLS: GachaPool[] = [
     cost: 10,
     currency: 'gems',
     rates: {
-      [Rarity.COMMON]: 0.35,     // 35%
-      [Rarity.UNCOMMON]: 0.3,    // 30%
-      [Rarity.RARE]: 0.2,        // 20%
-      [Rarity.EPIC]: 0.1,        // 10%
-      [Rarity.LEGENDARY]: 0.04,  // 4%
-      [Rarity.MYTHIC]: 0.01      // 1%
+      [Rarity.COMMON]: 0.27,      // 27%
+      [Rarity.UNCOMMON]: 0.24,    // 24%
+      [Rarity.RARE]: 0.2,         // 20%
+      [Rarity.SUPER_RARE]: 0.12,  // 12%
+      [Rarity.EPIC]: 0.08,        // 8%
+      [Rarity.LEGENDARY]: 0.05,   // 5%
+      [Rarity.MYTHIC]: 0.02,      // 2%
+      [Rarity.IMMORTAL]: 0.01     // 1%
     },
     availableItems: ITEM_TEMPLATES
   }

--- a/src/data/itemTemplates.ts
+++ b/src/data/itemTemplates.ts
@@ -38,7 +38,17 @@ export const ITEM_TEMPLATES: ItemTemplate[] = [
     description: 'A sword imbued with the power of fire.',
     icon: '🔥'
   },
-  
+
+  // Super Rare Weapons
+  {
+    name: 'Photon Blade',
+    family: ItemFamily.WEAPON,
+    rarity: Rarity.SUPER_RARE,
+    basePower: 75,
+    description: 'A blade forged from condensed light.',
+    icon: '✨'
+  },
+
   // Epic Weapons
   {
     name: 'Dragon Fang',
@@ -117,6 +127,16 @@ export const ITEM_TEMPLATES: ItemTemplate[] = [
     basePower: 300,
     description: 'A being from beyond the stars.',
     icon: '🌟'
+  },
+
+  // Immortal Characters
+  {
+    name: 'Time Weaver',
+    family: ItemFamily.CHARACTER,
+    rarity: Rarity.IMMORTAL,
+    basePower: 500,
+    description: 'An eternal being that manipulates time itself.',
+    icon: '⏳'
   }
 ];
 
@@ -124,16 +144,20 @@ export const RARITY_COLORS = {
   [Rarity.COMMON]: 'from-gray-400 to-gray-600',
   [Rarity.UNCOMMON]: 'from-green-400 to-green-600',
   [Rarity.RARE]: 'from-blue-400 to-blue-600',
+  [Rarity.SUPER_RARE]: 'from-teal-400 to-teal-600',
   [Rarity.EPIC]: 'from-purple-400 to-purple-600',
   [Rarity.LEGENDARY]: 'from-orange-400 to-orange-600',
-  [Rarity.MYTHIC]: 'from-pink-400 to-pink-600'
+  [Rarity.MYTHIC]: 'from-pink-400 to-pink-600',
+  [Rarity.IMMORTAL]: 'from-yellow-400 to-yellow-600'
 };
 
 export const RARITY_GLOW = {
   [Rarity.COMMON]: 'shadow-gray-400/50',
   [Rarity.UNCOMMON]: 'shadow-green-400/50',
   [Rarity.RARE]: 'shadow-blue-400/50',
+  [Rarity.SUPER_RARE]: 'shadow-teal-400/50',
   [Rarity.EPIC]: 'shadow-purple-400/50',
   [Rarity.LEGENDARY]: 'shadow-orange-400/50',
-  [Rarity.MYTHIC]: 'shadow-pink-400/50'
+  [Rarity.MYTHIC]: 'shadow-pink-400/50',
+  [Rarity.IMMORTAL]: 'shadow-yellow-400/50'
 };

--- a/src/services/gachaService.ts
+++ b/src/services/gachaService.ts
@@ -6,10 +6,14 @@ export class GachaService {
     return GACHA_POOLS.find(pool => pool.id === poolId);
   }
 
-  static performSummon(pool: GachaPool): Item {
+  static performSummon(pool: GachaPool): Item | null {
     const rarity = this.rollRarity(pool.rates);
+    if (!rarity) {
+      return null; // Nothing or basic resource
+    }
+
     const availableItems = pool.availableItems.filter(item => item.rarity === rarity);
-    
+
     if (availableItems.length === 0) {
       // Fallback to common if no items of rolled rarity
       const commonItems = pool.availableItems.filter(item => item.rarity === Rarity.COMMON);
@@ -21,15 +25,15 @@ export class GachaService {
     return this.createItemFromTemplate(template);
   }
 
-  static performMultiSummon(pool: GachaPool, count: number): Item[] {
-    const results: Item[] = [];
+  static performMultiSummon(pool: GachaPool, count: number): (Item | null)[] {
+    const results: (Item | null)[] = [];
     for (let i = 0; i < count; i++) {
       results.push(this.performSummon(pool));
     }
     return results;
   }
 
-  private static rollRarity(rates: Record<Rarity, number>): Rarity {
+  private static rollRarity(rates: Record<Rarity, number>): Rarity | null {
     const random = Math.random();
     let cumulative = 0;
 
@@ -40,7 +44,7 @@ export class GachaService {
       }
     }
 
-    return Rarity.COMMON; // Fallback
+    return null; // No item
   }
 
   private static createItemFromTemplate(template: ItemTemplate): Item {
@@ -82,9 +86,11 @@ export class GachaService {
       [Rarity.COMMON]: 1,
       [Rarity.UNCOMMON]: 2,
       [Rarity.RARE]: 4,
+      [Rarity.SUPER_RARE]: 6,
       [Rarity.EPIC]: 8,
       [Rarity.LEGENDARY]: 16,
-      [Rarity.MYTHIC]: 32
+      [Rarity.MYTHIC]: 32,
+      [Rarity.IMMORTAL]: 64
     };
     return multipliers[rarity];
   }

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -33,9 +33,11 @@ export enum Rarity {
   COMMON = 'common',
   UNCOMMON = 'uncommon',
   RARE = 'rare',
+  SUPER_RARE = 'super_rare',
   EPIC = 'epic',
   LEGENDARY = 'legendary',
-  MYTHIC = 'mythic'
+  MYTHIC = 'mythic',
+  IMMORTAL = 'immortal'
 }
 
 export enum ItemFamily {


### PR DESCRIPTION
## Summary
- extend `Rarity` with `SUPER_RARE` and `IMMORTAL`
- add item templates, colors, and glow effects for the new rarities
- update gacha pools and service to support new rarities and no-drop outcomes
- award coins when summons yield no items

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 9 errors, 3 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4f2c7b384832eab32be3f772860e2